### PR TITLE
compress `alloc` before destructuring expression into context and redex

### DIFF
--- a/pcf/heap/semantics.rkt
+++ b/pcf/heap/semantics.rkt
@@ -21,14 +21,14 @@
    (where ((M_1 Σ_1))
 	  ,(apply-reduction-relation* -->v& (term (M_0 Σ_0))))])
 
-(define vσ1
+(define -->vσ1
   (reduction-relation
    PCFΣ #:domain (M Σ)
    (--> (M_0 Σ_0)
 	(M_1 Σ_1)
 	(where (M_2 Σ_2) (&* (M_0 Σ_0)))
 	(where (_ ... (any_name (M_1 Σ_1)) _ ...)
-	       ,(apply-reduction-relation/tag-with-names vσ (term (M_2 Σ_2))))
+	       ,(apply-reduction-relation/tag-with-names (liftσ PCFΣ vσ) (term (M_2 Σ_2))))
 	(computed-name (term any_name)))))
 
 
@@ -83,7 +83,7 @@
 	err-abort)))
 
 (define -->vσ
-  (union-reduction-relations (liftσ PCFΣ vσ1) err-abortσ))
+  (union-reduction-relations -->vσ1 err-abortσ))
 
 
 (define-metafunction PCFΣ


### PR DESCRIPTION
Recent compressing of alloc steps breaks several tests (e.g. `(fact 5)` and `(add1 (quotient 5 0))`) because allocation turns some redexes into non-redexes, making `vσ` stuck. This pull request attempts to fix that by performing the context/redex splitting after allocations.
