### PR TITLE
fix pattern in scpcf's havoc rule + fix implementation of `/`

### DIFF
--- a/pcf/semantics.rkt
+++ b/pcf/semantics.rkt
@@ -70,8 +70,6 @@
   [(δf <= L (N_0 N_1))        ,(if (<= (term N_0) (term N_1)) 0 1)]
   [(δf >= L (N_0 N_1))        ,(if (>= (term N_0) (term N_1)) 0 1)]  
   [(δf not L (N))             ,(if (zero? (term N)) 1 0)]  
-  [(δf / L (N_0 0))    (err L nat "Divide by zero")]
-  [(δf / L (N_0 N_1)) ,(quotient (term N_0) (term N_1))]
-  [(δf quotient L (N_0 0))    (err L nat "Divide by zero")]
-  [(δf quotient L (N_0 N_1)) ,(quotient (term N_0) (term N_1))])
+  [(δf ÷ L (N_0 0))    (err L nat "Divide by zero")]
+  [(δf ÷ L (N_0 N_1)) ,(quotient (term N_0) (term N_1))])
 

--- a/pcf/syntax.rkt
+++ b/pcf/syntax.rkt
@@ -18,7 +18,9 @@
   ;; Variables
   (X ::= variable-not-otherwise-mentioned)
   ;; Type environments
-  (Γ ::= ((X T) ...)))
+  (Γ ::= ((X T) ...))
+  ;; `quotient` and `/` are aliases for now
+  (÷ quotient /))
 
 (define-extended-language PCF PCF-source
   ;; Labels

--- a/scpcf/heap/semantics.rkt
+++ b/scpcf/heap/semantics.rkt
@@ -78,10 +78,10 @@
         ((havoc TC ... V) Σ)        
         (where ((TC_0 ... -> TC_n) ...)
                (get Σ A_f))
-        (where ((V_0) ...)            ;; Ugh.  WTF to do here?
+        (where ((any_V) ...) ; `get` may return non-V
                ((get Σ A_V) ...))
-        (where (_ ... (V TC ...) _ ...)
-               ,(transpose (term ((V_0 ...)
+        (where (_ ... (V TC ...) _ ...) ; only pick out concrete V
+               ,(transpose (term ((any_V ...)
                                   (TC_0 ...)
                                   ...))))
         havoc)
@@ -128,29 +128,29 @@
 
   ;; FIXME: Add equation between result and inputs
   ;; Requires more primitives (=, etc.)
-  [(δσ^ quotient L (A_n A_d) Σ ((• nat) (refine Σ A_d pos?)) δ-quotient1)
+  [(δσ^ ÷ L (A_n A_d) Σ ((• nat) (refine Σ A_d pos?)) δ-÷1)
    (where (N) (get Σ A_n))
    (where (nat C ...) (get Σ A_d))  
    (side-condition (¬∈ N 0))]
       
-  [(δσ^ quotient L (A_n A_d) Σ (0 (refine Σ A_d pos?)) δ-quotient2)
+  [(δσ^ ÷ L (A_n A_d) Σ (0 (refine Σ A_d pos?)) δ-÷2)
    (where (0) (get Σ A_n))
    (where (nat C ...) (get Σ A_d))]
   
-  [(δσ^ quotient L (any A_d) Σ ((• nat) Σ) δ-quotient3)
+  [(δσ^ ÷ L (any A_d) Σ ((• nat) Σ) δ-÷3)
    (where (nat C_0 ... pos? C_1 ...) (get Σ A_d))]
   
-  [(δσ^ quotient L (any A_d) Σ 
+  [(δσ^ ÷ L (any A_d) Σ 
         ((err L nat "Divide by zero") 
-         (refine Σ A_d zero?)) δ-quotient4)
+         (refine Σ A_d zero?)) δ-÷4)
    (where (nat C ...) (get Σ A_d))        
    (side-condition (¬∈ pos? C ...))]
   
-  [(δσ^ quotient L (A_n A_d) Σ ((err L nat "Divide by zero") Σ) δ-quotient5)
+  [(δσ^ ÷ L (A_n A_d) Σ ((err L nat "Divide by zero") Σ) δ-÷5)
    (where (nat C ...) (get Σ A_n))
    (where (0) (get Σ A_d))]
   
-  [(δσ^ quotient L (A_n A_d) Σ ((• nat) Σ) δ-quotient6)
+  [(δσ^ ÷ L (A_n A_d) Σ ((• nat) Σ) δ-÷6)
    (where (nat C ...) (get Σ A_n))
    (where (N) (get Σ A_d))
    (side-condition (¬∈ N 0))]
@@ -188,7 +188,7 @@
   ;; FIXME: This rule probably needs to be treated more precisely
   [(δσ^ O L (any_0 ... A any_1 ...) Σ ((• nat) Σ) RULE)
    (where (nat C ...) (get Σ A))
-   (side-condition (¬∈ O quotient zero? pos? add1 =))])
+   (side-condition (¬∈ O quotient / zero? pos? add1 =))])
 
 
 ;; FIXME: should have refinements of concrete values too

--- a/scpcf/semantics.rkt
+++ b/scpcf/semantics.rkt
@@ -70,25 +70,14 @@
   #:mode (δ^ I I I O)
   #:contract (δ^ O L (V ...) M)
 
-  [(δ^ quotient L (N (• nat C ...)) (• nat))
+  [(δ^ ÷ L (N (• nat C ...)) (• nat))
    (side-condition (¬∈ N 0))]
-  [(δ^ quotient L (0 (• nat C ...)) 0)]
-  [(δ^ quotient L (any (• nat C_0 ... pos? C_1 ...)) (• nat))]
-  [(δ^ quotient L (any (• nat C ...)) (err L nat "Divide by zero"))
+  [(δ^ ÷ L (0 (• nat C ...)) 0)]
+  [(δ^ ÷ L (any (• nat C_0 ... pos? C_1 ...)) (• nat))]
+  [(δ^ ÷ L (any (• nat C ...)) (err L nat "Divide by zero"))
    (side-condition (¬∈ pos? C ...))]
-  [(δ^ quotient L ((• nat C ...) 0)   (err L nat "Divide by zero"))]
-  [(δ^ quotient L ((• nat C ...) N)   (• nat))
-   (side-condition (¬∈ N 0))]
-
-  ;; Dup for /
-  [(δ^ / L (N (• nat C ...)) (• nat))
-   (side-condition (¬∈ N 0))]
-  [(δ^ / L (0 (• nat C ...)) 0)]
-  [(δ^ / L (any (• nat C_0 ... pos? C_1 ...)) (• nat))]
-  [(δ^ / L (any (• nat C ...)) (err L nat "Divide by zero"))
-   (side-condition (¬∈ pos? C ...))]
-  [(δ^ / L ((• nat C ...) 0)   (err L nat "Divide by zero"))]
-  [(δ^ / L ((• nat C ...) N)   (• nat))
+  [(δ^ ÷ L ((• nat C ...) 0)   (err L nat "Divide by zero"))]
+  [(δ^ ÷ L ((• nat C ...) N)   (• nat))
    (side-condition (¬∈ N 0))]
 
   [(δ^ pos? L ((• nat C_1 ... pos? C_2 ...)) 0)]

--- a/spcf/semantics.rkt
+++ b/spcf/semantics.rkt
@@ -34,7 +34,7 @@
 
 (define-metafunction SPCF
   not-div? : any -> #t or #f
-  [(not-div? div) #f]
+  [(not-div? ÷) #f]
   [(not-div? any) #t])
 
 (define -->sv
@@ -44,10 +44,10 @@
 (define-judgment-form SPCF
   #:mode (δ^ I I I O)
   #:contract (δ^ O L (V ...) M)
-  [(δ^ quotient L (any (• nat)) (• nat))]
-  [(δ^ quotient L (any (• nat)) (err L nat "Divide by zero"))]
-  [(δ^ quotient L ((• nat) 0)   (err L nat "Divide by zero"))]
-  [(δ^ quotient L ((• nat) N)   (• nat))
+  [(δ^ ÷ L (any (• nat)) (• nat))]
+  [(δ^ ÷ L (any (• nat)) (err L nat "Divide by zero"))]
+  [(δ^ ÷ L ((• nat) 0)   (err L nat "Divide by zero"))]
+  [(δ^ ÷ L ((• nat) N)   (• nat))
    (side-condition (not-zero? N))]
   [(δ^ O L (any_0 ... (• nat) any_1 ...) (• nat))
    (side-condition (not-div? O))])


### PR DESCRIPTION
This pull request:
- Fixes pattern in `scpcf/heap/semantics.rkt`'s `havoc` not matching when some of the argument is opaque
- Fixes `/` as an alias for `quotient` (I define `÷` as both)
