### PR TITLE
either print fully concrete counterexample or admit we fail to find one

### DIFF
--- a/pcf/private/return.rkt
+++ b/pcf/private/return.rkt
@@ -1,7 +1,7 @@
 #lang racket
 (provide return returnσ pp ppσ ppσ* color)
 (require (only-in redex/gui term-node-parents term-node-labels))
-(require redex/reduction-semantics scpcf/heap/semantics)
+(require redex/reduction-semantics scpcf/heap/semantics scpcf/syntax)
 (require unstable/lazy-require)
 (lazy-require (redex/gui [default-pretty-printer]))
 
@@ -39,7 +39,7 @@
             (syntax->srcstring l)
             c0 c1 v)
     (cond
-     [(hash-empty? cs) '()]
+     [(hash-empty? cs) '("\n(Unable to come up with counterexample)")]
      [else
       (list*
        "\nPossible breaking context:"
@@ -55,7 +55,7 @@
     string-append
     (format "err:~a ~a" (syntax->srcstring l) s)
     (cond
-     [(hash-empty? cs) '()]
+     [(hash-empty? cs) '("\n(Unable to come up with counterexample)")]
      [else
       (list*
        "\nPossible breaking context:"
@@ -74,10 +74,14 @@
             [(list (list* 'err _) 'with _) #f]
 	    [_ #t]))
 
+(define T? (redex-match? SCPCF T))
+(define O? (redex-match? SCPCF O))
 (define (scrub v)
   (match v
     [(list '@ l m ...)
      (map scrub m)]
+    [(list '• TC ...) ; only keep simple contracts
+     (list* '• (for/list ([tc TC] #:when (or (T? tc) (O? tc))) tc))]
     [(list 'err l t s)
      (list 'err #;(loc l) #;t s)]
     [(list 'blame 'HAVOC c0 c1 v)

--- a/scpcf/heap/examples.rkt
+++ b/scpcf/heap/examples.rkt
@@ -6,3 +6,16 @@
 
 ((• 2 ((((nat -> nat) -> nat) -> nat) -> nat))
  (λ ([f : ((nat -> nat) -> nat)]) (f (λ ([x : nat]) (/ 1 x)))))
+
+((• 3 ((nat -> nat) -> nat))
+ (λ ([x : nat]) (/ 1 (- 10 x))))
+
+; (No error)
+((• 4 ((nat -> nat) -> nat))
+ (λ ([x : nat]) (/ 1 (+ 10 x))))
+
+((• 5 ((nat -> nat) -> nat))
+ (μ (f : (nat -> nat))
+    (λ ([n : nat])
+      (if0 (zero? n) 1
+           (+ (/ 2 (- 13 n)) (f (/ 1 (- 7 n))))))))


### PR DESCRIPTION
This pull request:
- ensures the counterexample is always fully concrete
- remembers equations between arguments and results
- simplifies and improves precision of  `δσ^` for division by using the provability relation rather than doing manual checking
- adds more examples for printing counterexamples
