### PR TITLE
remember finite mappings in opaque functions

### DIFF
--- a/pcf/heap/semantics.rkt
+++ b/pcf/heap/semantics.rkt
@@ -127,8 +127,8 @@
    ,(hash-set (term any_Σ) (term any_A) (list (term T) (apply set (term (any_C ...)))))]
   [(put₁ any_Σ any_A (• L T any_C ...))
    ,(hash-set (term any_Σ) (term any_A) (list (term T) (apply set (term (any_C ...)))))]
-  [(put₁ any_Σ any_A (any_T any_C ...))
-   ,(hash-set (term any_Σ) (term any_A) (list (term any_T) (apply set (term (any_C ...)))))]
+  [(put₁ any_Σ any_A (T any_C ...))
+   ,(hash-set (term any_Σ) (term any_A) (list (term T) (apply set (term (any_C ...)))))]
   [(put₁ any_Σ any_A any_V)
    ,(hash-set (term any_Σ) (term any_A) (list (term any_V) (set)))])
 

--- a/pcf/private/return.rkt
+++ b/pcf/private/return.rkt
@@ -39,7 +39,7 @@
             (syntax->srcstring l)
             c0 c1 v)
     (cond
-     [(hash-empty? cs) '("\n(Unable to come up with counterexample)")]
+     [(hash-empty? cs) '()]
      [else
       (list*
        "\nPossible breaking context:"
@@ -55,7 +55,7 @@
     string-append
     (format "err:~a ~a" (syntax->srcstring l) s)
     (cond
-     [(hash-empty? cs) '("\n(Unable to come up with counterexample)")]
+     [(hash-empty? cs) '()]
      [else
       (list*
        "\nPossible breaking context:"

--- a/scpcf/heap/examples.rkt
+++ b/scpcf/heap/examples.rkt
@@ -1,4 +1,4 @@
-#lang scpcf/heap
+#lang scpcf/heap traces
 
 ((• 1 ((nat -> nat) (nat -> nat) -> nat))
  (λ ([x : nat]) (/ 1 x))
@@ -19,3 +19,11 @@
     (λ ([n : nat])
       (if0 (zero? n) 1
            (+ (/ 2 (- 13 n)) (f (/ 1 (- 7 n))))))))
+
+((• 1 (((nat -> nat) -> (nat -> nat)) -> nat))
+ (λ ([f : (nat -> nat)])
+   (λ ([x : nat]) (/ 10 (f x)))))
+
+((• 1 (((nat -> nat) -> nat) -> nat))
+ (λ ([f : (nat -> nat)])
+   (/ 10 (- 10 (* (f 5) (f 7))))))

--- a/scpcf/heap/syntax.rkt
+++ b/scpcf/heap/syntax.rkt
@@ -1,5 +1,5 @@
 #lang racket
-(provide SCPCFΣ)
+(provide SCPCFΣ fin@ fin+)
 (require redex/reduction-semantics
          scpcf/syntax)
 
@@ -7,7 +7,7 @@
   (A ::= integer)
   (P ::= (& A))
   (M ::= .... P)
-  (V ::= N O (λ ([X : T] ...) M) (P ... -> P) (• T C ...) (• L T C ...))
+  (V ::= N O (λ ([X : T] ...) M) (P ... -> P) (• T C ...) (• L T C ...) Fin)
   (E ::= hole 
      (@ L P ... E M ...) 
      (if0 E M M)     
@@ -16,9 +16,21 @@
      (E L L C ⚖ M)
      (P L L C ⚖ E))
   
-  (F ::= .... (T -> nat))
+  (F ::= .... (T -> nat) Fin)
   ;; Without, the ? rule in CPCFΣ breaks when lifted to SCPCΣ
+  (Fin ::= (fin (T ... -> T) (A ... ↦ A) ...))
   
   (S ::= (TV C ...))
   (TV ::= T V)
   (Σ ::= (side-condition any_0 (hash? (term any_0))))) ; A -> S
+
+;; Look up finite function or return `#f` if no match
+(define-metafunction SCPCFΣ
+  fin@ : Fin A ... -> A or #f
+  [(fin@ (fin _ ... (A ... ↦ A_y) _ ...) A ...) A_y]
+  [(fin@ _ _) #f])
+
+;; Extend finite function
+(define-metafunction SCPCFΣ
+  fin+ : Fin (A ... ↦ A) -> Fin
+  [(fin+ (fin any ...) any_1) (fin any ... any_1)])


### PR DESCRIPTION
This pull request:
- Remembers finite mappings in opaque functions to help rebuilding counterexamples
- Add examples
- Remove wrong message "Unable to find counterexample"
