### PR TITLE
encode (x = y => fx = fy), fixing previous false counterexample

### DIFF
--- a/scpcf/heap/examples.rkt
+++ b/scpcf/heap/examples.rkt
@@ -31,3 +31,7 @@
 ((• 8 (((nat -> nat) nat nat -> nat) -> nat))
  (λ ([f : (nat -> nat)] [x : nat] [y : nat])
    (/ 1 (- 10 (* (f x) (f y))))))
+
+((• 9 (((nat nat -> nat) nat nat nat nat -> nat) -> nat))
+ (λ ([f : (nat nat -> nat)] [a : nat] [b : nat] [c : nat] [d : nat])
+   (/ 1 (- 10 (* (f a b) (f c d))))))

--- a/scpcf/heap/syntax.rkt
+++ b/scpcf/heap/syntax.rkt
@@ -28,7 +28,7 @@
 (define-metafunction SCPCFΣ
   fin@ : Fin A ... -> A or #f
   [(fin@ (fin _ ... (A ... ↦ A_y) _ ...) A ...) A_y]
-  [(fin@ _ _) #f])
+  [(fin@ _ _ ...) #f])
 
 ;; Extend finite function
 (define-metafunction SCPCFΣ


### PR DESCRIPTION
This pull request encodes knowledge about the relation between arguments and results of functions, i.e. (`x` ... = `y` ...) implies (`fx⋯` = `fy⋯`), where `fx⋯` is the symbol resulting from (`f` `x` ...) 
