### PR TITLE
Replace dependency on `unstable/lazy-require` with `racket/lazy-require`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,8 +5,7 @@
 (define deps 
   '("base" 
     "redex-lib" 
-    "redex-pict-lib" 
-    "unstable-lib"))
+    "redex-pict-lib"))
 
 (define build-deps 
   '("scribble-lib" 

--- a/pcf/private/make-lang.rkt
+++ b/pcf/private/make-lang.rkt
@@ -32,7 +32,7 @@
      (define trace (attribute trace.sym))
      #`(#%module-begin
         (lexical e) ... ; lexical expansion for IDE integration
-	(require unstable/lazy-require)
+	(require racket/lazy-require)
 	(lazy-require [redex (traces stepper initial-char-width 
                                      term-node-children reduction-steps-cutoff
                                      default-pretty-printer)])        

--- a/pcf/private/return.rkt
+++ b/pcf/private/return.rkt
@@ -2,7 +2,7 @@
 (provide return returnσ pp ppσ ppσ* color)
 (require (only-in redex/gui term-node-parents term-node-labels))
 (require redex/reduction-semantics scpcf/heap/semantics scpcf/syntax)
-(require unstable/lazy-require)
+(require racket/lazy-require)
 (lazy-require (redex/gui [default-pretty-printer]))
 
 (define (return res)


### PR DESCRIPTION
`unstable/lazy-require` is likely to go away in the future, and the functionality this package depends on is already provided by `racket/lazy-require`.